### PR TITLE
Update link to GitHub in Help menu

### DIFF
--- a/apps/sim-core/packages/core/src/components/HashCore/Header/Menu/Help/HashCoreHeaderMenuHelp.tsx
+++ b/apps/sim-core/packages/core/src/components/HashCore/Header/Menu/Help/HashCoreHeaderMenuHelp.tsx
@@ -81,11 +81,11 @@ export const HashCoreHeaderMenuHelp: FC<HashCoreHeaderMenuHelpProps> = memo(
           </li>
           <li className="HashCoreHeaderMenu-submenu-item">
             <a
-              href={"https://github.com/hashintel/labs/tree/main/apps/sim-core"}
+              href={"https://github.com/hashintel/labs/issues/new/choose"}
               target="_blank"
               rel="noopener noreferrer"
             >
-              GitHub
+              Report an issue
             </a>
           </li>
         </ul>


### PR DESCRIPTION
This PR updates the link in the `Help` menu to go to the GitHub 'create issue' page rather than the README.