### PR TITLE
Ignore current `apps` and all current/future POCs in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,13 @@
   "rebaseWhen": "conflicted",
   "semanticCommits": "disabled",
 
+  "ignorePaths": [
+      "apps/sim-core/",
+      "apps/sim-core-plugins/",
+      "apps/sim-engine/",
+      "pocs/",
+  ],
+
   "packageRules": [
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
       "apps/sim-core/",
       "apps/sim-core-plugins/",
       "apps/sim-engine/",
-      "pocs/",
+      "pocs/"
   ],
 
   "packageRules": [


### PR DESCRIPTION
Self-explanatory.

See the docs: https://docs.renovatebot.com/configuration-options/#ignorepaths