### PR TITLE
Support the 3 variant mime types for zip files

### DIFF
--- a/apps/sim-core/packages/core/src/features/files/hooks.ts
+++ b/apps/sim-core/packages/core/src/features/files/hooks.ts
@@ -124,7 +124,12 @@ export const useImportFiles = () => {
     }
     const file = files[0];
 
-    if (file.type !== "application/zip") {
+    const zipMimeTypes = [
+      "application/zip",
+      "application/zip-compressed",
+      "application/x-zip-compressed",
+    ];
+    if (!zipMimeTypes.includes(file.type)) {
       throw "Please upload a .zip file";
     }
 


### PR DESCRIPTION
-- fixes 'project import' in contexts where the environment chooses one of the 2 varients we didn't previously support.