### PR TITLE
H-6402: Add preflight workflow

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,71 @@
+name: Housekeeping
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/housekeeping.yml"
+      - ".github/renovate.json"
+  schedule:
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      repoCache:
+        description: "Reset or disable the cache?"
+        type: choice
+        default: enabled
+        options:
+          - enabled
+          - disabled
+          - reset
+      logLevel:
+        description: "Override default log level"
+        type: choice
+        default: info
+        options:
+          - "debug"
+          - "info"
+          - "warn"
+          - "error"
+      overrideSchedule:
+        description: "Override all schedules"
+        type: boolean
+        default: false
+      dryRun:
+        description: "Dry run mode"
+        type: choice
+        default: disabled
+        options:
+          - disabled
+          - extract
+          - lookup
+          - full
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+
+jobs:
+  validate:
+    name: Validate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate Renovate config
+        run: jq empty .github/renovate.json
+
+      - name: Validate workflow
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/housekeeping.yml
+
+  renovate:
+    name: Dependencies
+    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@a0df113e5602f3b721bf306bf6050ee2a0866956
+    with:
+      repoCache: ${{ inputs.repoCache || 'enabled' }}
+      logLevel: ${{ inputs.logLevel || 'info' }}
+      overrideSchedule: ${{ inputs.overrideSchedule || false }}
+      dryRun: ${{ inputs.dryRun || 'disabled' }}
+    secrets: inherit

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -21,17 +21,17 @@ jobs:
       # see: https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
       id-token: write
       pull-requests: write
-    uses: hashintel/.github/.github/workflows/dismiss-stale-approvals.yml@52c4a1f5fa1c72f30dfa02b00a6cbf0c89c1ea8a
+    uses: hashintel/.github/.github/workflows/preflight-stale-approvals.yml@a0df113e5602f3b721bf306bf6050ee2a0866956
 
   dependencies:
     name: Dependencies
     permissions:
       contents: read
       pull-requests: write
-    uses: hashintel/.github/.github/workflows/dependencies.yml@52c4a1f5fa1c72f30dfa02b00a6cbf0c89c1ea8a
+    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@a0df113e5602f3b721bf306bf6050ee2a0866956
 
   todo-comments:
     name: Todo comments
     permissions:
       contents: read
-    uses: hashintel/.github/.github/workflows/todo-comments.yml@52c4a1f5fa1c72f30dfa02b00a6cbf0c89c1ea8a
+    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@a0df113e5602f3b721bf306bf6050ee2a0866956

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,37 @@
+name: Preflight
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/preflight.yml"
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+  merge_group:
+
+jobs:
+  stale-approvals:
+    name: Stale approvals
+    permissions:
+      actions: read
+      contents: read
+      # Required by the reusable workflow to extract job_workflow_ref from the
+      # OIDC token to resolve the correct checkout ref for the composite action.
+      # see: https://github.com/actions/toolkit/issues/1264
+      # TODO: Remove once $/ syntax is available
+      # see: https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
+      id-token: write
+      pull-requests: write
+    uses: hashintel/.github/.github/workflows/dismiss-stale-approvals.yml@52c4a1f5fa1c72f30dfa02b00a6cbf0c89c1ea8a
+
+  dependencies:
+    name: Dependencies
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: hashintel/.github/.github/workflows/dependencies.yml@52c4a1f5fa1c72f30dfa02b00a6cbf0c89c1ea8a
+
+  todo-comments:
+    name: Todo comments
+    permissions:
+      contents: read
+    uses: hashintel/.github/.github/workflows/todo-comments.yml@52c4a1f5fa1c72f30dfa02b00a6cbf0c89c1ea8a


### PR DESCRIPTION
## Summary
- Adds `preflight.yml` calling reusable workflows from the `.github` org repo
- Stale approvals: dismisses PR approvals when the diff changes
- Dependencies: reviews dependency changes for known vulnerabilities
- TODO comments: scans for TODO comments referencing Linear tickets from the PR title

## Related
- hashintel/.github#35