### PR TITLE
SRE-737: Remove dismiss-stale-approvals preflight job

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -9,35 +9,21 @@ on:
   merge_group:
 
 jobs:
-  stale-approvals:
-    name: Stale approvals
-    permissions:
-      actions: read
-      contents: read
-      # Required by the reusable workflow to extract job_workflow_ref from the
-      # OIDC token to resolve the correct checkout ref for the composite action.
-      # see: https://github.com/actions/toolkit/issues/1264
-      # TODO: Remove once $/ syntax is available
-      # see: https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
-      id-token: write
-      pull-requests: write
-    uses: hashintel/.github/.github/workflows/preflight-stale-approvals.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
-
   dependencies:
     name: Dependencies
     permissions:
       contents: read
       pull-requests: write
-    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
+    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@ae4227bc6b6375f06ac30093826318283eefb203
 
   todo-comments:
     name: Todo comments
     permissions:
       contents: read
-    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
+    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@ae4227bc6b6375f06ac30093826318283eefb203
 
   pr-title:
     name: PR title
     permissions:
       contents: read
-    uses: hashintel/.github/.github/workflows/preflight-pr-title.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
+    uses: hashintel/.github/.github/workflows/preflight-pr-title.yml@ae4227bc6b6375f06ac30093826318283eefb203


### PR DESCRIPTION
## Purpose

Remove the dangling `stale-approvals` preflight job. The `dismiss-stale-approvals` reusable workflow + action were deleted from `hashintel/.github` (SRE-737); stale-approval dismissal is now GitHub-native via the org branch-protection rulesets.

## What does this change?

- Drop the `stale-approvals` job from `.github/workflows/preflight.yml`
- Bump the remaining preflight refs (`dependencies`, `todo-comments`, `pr-title`) to the new `.github` SHA `ae4227b`

Related: SRE-737 · hashintel/.github#70
