### PR TITLE
SRE-901: Stop handing CI more Vault reach than it uses

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -42,7 +42,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
@@ -68,4 +68,3 @@ jobs:
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ inputs.overrideSchedule || false }}
       dryRun: ${{ inputs.dryRun || 'disabled' }}
-    secrets: inherit


### PR DESCRIPTION
Applies the CI Vault narrowing from hashintel/hash#9160 to this repo.

- **`secrets: inherit` dropped** from the `renovate` job. The pinned reusable workflow reads no `secrets.*` — the Vault address comes from `vars.VAULT_ADDR`, a repo variable, which `secrets: inherit` never carried.
- **`contents: write` → `read`.** The reusable workflow declares `contents: read` for itself, so the Renovate job's token is already read-only in the current scheduled runs. The caller-side `write` only reached this workflow's own `validate` job, which checks out and runs `jq`/`actionlint`.

## Related links

- [SRE-901](https://linear.app/hash/issue/SRE-901/harden-the-centralized-renovate-workflow-against-compromised-actions) _(internal)_
- hashintel/hash#9160 — the same change in `hash`

## What tests cover this?

`actionlint` v1.7.12 on the changed file: clean. Renovate is proven green under `contents: read`, since that is already its effective permission today.
