### PR TITLE
SRE-924: Pass the Vault access token and scope permissions per job

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -40,16 +40,15 @@ on:
           - lookup
           - full
 
-permissions:
-  actions: read
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   validate:
     name: Validate
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,9 +61,15 @@ jobs:
 
   renovate:
     name: Dependencies
-    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@9957be5b132761d8b54dea2eb3166f417ebacaf9 # main
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@89ff06bc761f0c0491d87a766eccce5aae6190ea # main
     with:
       repoCache: ${{ inputs.repoCache || 'enabled' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ inputs.overrideSchedule || false }}
       dryRun: ${{ inputs.dryRun || 'disabled' }}
+    secrets:
+      CF_ACCESS_STAGE_CLIENT_SECRET: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}


### PR DESCRIPTION
Adapts this caller to the Renovate workflow's new contract from hashintel/.github#95.

- **`CF_ACCESS_STAGE_CLIENT_SECRET` passed explicitly.** The reusable workflow now declares it as a required secret. A called workflow does not inherit secrets the way it resolves `vars`, and `secrets: inherit` is gone since SRE-901, so without this line the job fails at dispatch.
- **Permissions moved to the jobs that need them.** `id-token: write` was granted workflow-wide, which also handed it to the `validate` job — that job only checks out and runs `jq`/`actionlint`. The `renovate` job now carries exactly what the reusable workflow declares, and `validate` gets `contents: read`.
- **Re-pinned** to `89ff06bc`, the merge commit of #95.

`environment:` is not available on a job that calls a reusable workflow, which is why the Vault tier comes from the suffixed `vars.VAULT_STAGE_ADDR` here rather than from an environment as it does in `release.yml`.

## Related links

- [SRE-924](https://linear.app/hash/issue/SRE-924/sign-the-github-app-jwt-with-vault-transit-instead-of-handing-ci-the) _(internal)_
- hashintel/.github#95 — the reusable workflow this follows
- hashintel/internal-infra#321 — the transit key and `ci-renovate` role

## What tests cover this?

`actionlint` v1.7.12 clean locally, and the `Validate` job covers the file in CI. The real check is `Dependencies / Renovate` on this PR: it runs the full Vault auth and token mint against the new secret and permission set.
