### PR TITLE
SRE-891, SRE-904: Pass the Renovate cipher key and fix the todo-comments trigger

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -65,7 +65,7 @@ jobs:
       actions: read
       contents: read
       id-token: write
-    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@8c1a3b18a4f6528fc8eabcf9acda7780a1e47776 # main
+    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@b7a5d7f651c1d6a862d5dd97aa6164125bedb6c5 # main
     with:
       repoCache: ${{ inputs.repoCache || 'enabled' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
@@ -73,3 +73,4 @@ jobs:
       dryRun: ${{ inputs.dryRun || 'disabled' }}
     secrets:
       CF_ACCESS_STAGE_CLIENT_SECRET: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
+      RENOVATE_TOKEN_ENC_KEY: ${{ secrets.RENOVATE_TOKEN_ENC_KEY }}

--- a/.github/workflows/preflight-todo-comments.yml
+++ b/.github/workflows/preflight-todo-comments.yml
@@ -1,0 +1,14 @@
+name: Preflight
+
+on:
+  pull_request:
+    # `edited` matters: the scan derives its ticket IDs from the PR title.
+    types: [opened, synchronize, reopened, edited]
+  merge_group:
+
+jobs:
+  todo-comments:
+    name: Todo comments
+    permissions:
+      contents: read
+    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@b7a5d7f651c1d6a862d5dd97aa6164125bedb6c5 # main

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -14,16 +14,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@8c1a3b18a4f6528fc8eabcf9acda7780a1e47776 # main
-
-  todo-comments:
-    name: Todo comments
-    permissions:
-      contents: read
-    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@8c1a3b18a4f6528fc8eabcf9acda7780a1e47776 # main
+    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@b7a5d7f651c1d6a862d5dd97aa6164125bedb6c5 # main
 
   pr-title:
     name: PR title
     permissions:
       contents: read
-    uses: hashintel/.github/.github/workflows/preflight-pr-title.yml@8c1a3b18a4f6528fc8eabcf9acda7780a1e47776 # main
+    uses: hashintel/.github/.github/workflows/preflight-pr-title.yml@b7a5d7f651c1d6a862d5dd97aa6164125bedb6c5 # main


### PR DESCRIPTION
## Purpose

hashintel/.github#99 split the centralized Renovate workflow into a mint job and a run job; the installation token crosses the job boundary encrypted with `RENOVATE_TOKEN_ENC_KEY`. This wires the caller up to that contract, mirroring hashintel/hash#9192, and re-enables the todo-comments scan on PRs.

## Related links

- [SRE-904](https://linear.app/hash/issue/SRE-904) _(internal)_
- [SRE-891](https://linear.app/hash/issue/SRE-891) _(internal)_
- hashintel/.github#99
- hashintel/hash#9192

## What does this change?

- `housekeeping.yml`: bump the `hashintel/.github` pin to `b7a5d7f` and pass `RENOVATE_TOKEN_ENC_KEY` through to the reusable workflow (the secret is already set on this repo)
- `preflight.yml`: move the todo-comments job into a dedicated `preflight-todo-comments.yml` triggered on `pull_request` (matching hash and brunch). The reusable scan job is `pull_request`-only since SRE-891, so it was silently skipped when called under `pull_request_target`. The check name stays `Todo comments / Scan`.
- Remaining `hashintel/.github` pins bumped to the same SHA

## How to test this?

- The Housekeeping validate job runs actionlint on the changed workflow (also validated locally with actionlint 1.7.12)
- The `Todo comments / Scan` check on this PR should now report success/failure instead of skipped
